### PR TITLE
Fix `Stream::Write`

### DIFF
--- a/core/src/stream/stream.h
+++ b/core/src/stream/stream.h
@@ -34,17 +34,12 @@ public:
     void Write(uint32_t object_id, const std::string &data);
 
 private:
+
     void DoReadObjectID();
 
     void DoReadHeader(uint32_t object_id);
 
     void DoReadBody(uint32_t object_id, uint32_t body_size);
-
-    void DoWriteObjectID(uint32_t object_id, const std::function<void()> &done_callback);
-
-    void DoWriteHeader(uint32_t data_size, const std::function<void()> &done_callback);
-
-    void DoWriteBody(const std::string &data, const std::function<void()> &done_callback);
 
 private:
     uint64_t stream_id_;


### PR DESCRIPTION
`asio::buffer` is just a wrapper to wrap your memory. We should make sure the memory safe to use.
That means we don't know when `asio` use the memory, but we can make sure that once the callback done, the memory will never be used any more.