### PR TITLE
Support Java POJO as arguments and return value.

### DIFF
--- a/java/rpc-client/pom.xml
+++ b/java/rpc-client/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>msgpack-core</artifactId>
             <version>0.8.21</version>
         </dependency>
+        <dependency>
+            <groupId>org.msgpack</groupId>
+            <artifactId>jackson-dataformat-msgpack</artifactId>
+            <version>0.8.21</version>
+        </dependency>
+
     </dependencies>
     <build>
         <resources>

--- a/java/rpc-client/src/test/java/org/dousi/test/BasicTest.java
+++ b/java/rpc-client/src/test/java/org/dousi/test/BasicTest.java
@@ -1,5 +1,6 @@
 package org.dousi.test;
 
+
 import org.dousi.client.DousiRpcClient;
 import org.dousi.client.DousiService;
 import org.dousi.client.NativeRpcClient;
@@ -7,6 +8,34 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+
+// A POJO class.
+class PersonInfo implements java.io.Serializable {
+
+    private static final long serialVersionUID = 8010472539851795705L;
+
+    private String name;
+
+    private int age;
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public int getAge() {
+        return age;
+    }
+}
+
 
 public class BasicTest {
 
@@ -16,5 +45,18 @@ public class BasicTest {
         DousiService service = rpcClient.getService("Adder");
         CompletableFuture<Object> future = service.asyncFunction("add").invoke(Integer.class, 2, 3);
         Assert.assertEquals(future.get(), 5);
+    }
+
+    @Test
+    public void testPojoObjectAsArgumentAndReturn() throws ExecutionException, InterruptedException {
+        DousiRpcClient rpcClient = new NativeRpcClient("127.0.0.1:10002");
+        DousiService service = rpcClient.getService("UserDefinedClass");
+        PersonInfo p = new PersonInfo();
+        p.setName("Allen");
+        p.setAge(19);
+        CompletableFuture<Object> future = service.asyncFunction("IncrAge").invoke(PersonInfo.class, p, 2);
+        PersonInfo received = (PersonInfo) future.get();
+        Assert.assertEquals(received.getName(), "Allen");
+        Assert.assertEquals(received.getAge(), 21);
     }
 }


### PR DESCRIPTION
Assume that PersonInfo is your defined POJO, then use it as primitive type:
```java
        DousiRpcClient rpcClient = new NativeRpcClient("127.0.0.1:10002");
        DousiService service = rpcClient.getService("UserDefinedClass");
        PersonInfo p = new PersonInfo();
        p.setName("Allen");
        p.setAge(19);
        CompletableFuture<Object> future = service.asyncFunction("IncrAge").invoke(PersonInfo.class, p, 2);
        PersonInfo received = (PersonInfo) future.get();
        Assert.assertEquals(received.getName(), "Allen");
        Assert.assertEquals(received.getAge(), 21);
```

In the C++ server end, you should define the POJO class in `MSGPACK_DEFINE` macro as before.